### PR TITLE
Group output by repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
@@ -328,15 +328,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -345,21 +345,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -369,7 +369,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -380,6 +379,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "futures-util",
  "itertools",
  "octocrab",
  "reqwest",
@@ -821,12 +821,6 @@ name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "powerfmt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 anyhow = "1.0.98"
 chrono = "0.4.41"
 clap = { version = "4.5.42", features = ["derive"] }
+futures-util = "0.3.32"
 itertools = "0.14.0"
 octocrab = "0.44.1"
 reqwest = { version = "0.12.22", default-features = false, features = [

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use clap::Parser;
+use futures_util::future::try_join_all;
 use generate_dev_update::{list_prs, string_to_utc};
 use itertools::Itertools;
-use tokio::try_join;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -30,53 +30,37 @@ async fn main() -> Result<()> {
     end_date.date_naive()
   );
 
-  let (
-    lemmy_prs,
-    lemmy_ui_prs,
-    joinlemmy_prs,
-    jerboa_prs,
-    lemmy_js_client_prs,
-    lemmy_client_rs_prs,
-  ) = try_join!(
+  try_join_all([
     list_prs("lemmy", &start_date, &end_date),
     list_prs("lemmy-ui", &start_date, &end_date),
     list_prs("joinlemmy-site", &start_date, &end_date),
     list_prs("jerboa", &start_date, &end_date),
     list_prs("lemmy-js-client", &start_date, &end_date),
     list_prs("lemmy-client-rs", &start_date, &end_date),
-  )?;
-
-  let pull_requests = [
-    lemmy_prs,
-    lemmy_ui_prs,
-    joinlemmy_prs,
-    jerboa_prs,
-    lemmy_js_client_prs,
-    lemmy_client_rs_prs,
-  ]
-  .concat();
-
-  pull_requests
-    .into_iter()
-    .map(|pr| (pr.user.clone().unwrap().login, pr))
-    .sorted_by(|a, b| Ord::cmp(&b.0, &a.0))
-    // Group by author name
-    .chunk_by(|(author, _)| author.clone())
-    .into_iter()
-    .map(|chunk| (chunk.0, chunk.1.collect::<Vec<_>>()))
-    // Show authors with less PRs first
-    .sorted_by(|a, b| Ord::cmp(&a.1.len(), &b.1.len()))
-    // Print as markdown
-    .for_each(|pr| {
-      println!("\n## {}\n", pr.0);
-      for (_, pr) in pr.1 {
-        println!(
-          "- [{}]({})",
-          pr.title.clone().unwrap().trim(),
-          pr.html_url.unwrap().as_str()
-        );
-      }
-    });
+  ])
+  .await?
+  .into_iter()
+  .for_each(|pr| {
+    pr.into_iter()
+      .map(|pr| (pr.head.repo.clone().unwrap().name, pr))
+      .sorted_by(|a, b| Ord::cmp(&b.0, &a.0))
+      // Group by repo name
+      .chunk_by(|(repo, _)| repo.clone())
+      .into_iter()
+      .map(|chunk| (chunk.0, chunk.1.collect::<Vec<_>>()))
+      // Print as markdown
+      .for_each(|pr| {
+        println!("\n## {}\n", pr.0);
+        for (_, pr) in pr.1 {
+          println!(
+            "- [{}]({}) by @{}",
+            pr.title.clone().unwrap().trim(),
+            pr.html_url.clone().unwrap().as_str(),
+            pr.user.clone().unwrap().login
+          );
+        }
+      });
+  });
 
   println!("\n");
 


### PR DESCRIPTION
If we include so many repos, we need to group the output by repo name. Otherwise it becomes unreadable.